### PR TITLE
Refactoring and some improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,16 @@ Simple proxy layer for JavaScript `fetch()`. It helps do some http-requests excl
 > - few url param support (f.e: `'get/{type}/{id}'`)
 > - "headers" property is not required in `config.json`
 > - `text/plain` responses are available
+
 > ##### Breaking changes (0.1.0):
 > - New API (method names, method chaining template. See below). 
+
+> ##### Changelog (0.1.3):
+> - fix of query parameters encoding
+> - query parameters support for all queries types (`post`, `get`,...)
+> - api for response interception
+> - mark `RestApiHelper.configure` as deprecated. It's will be removed in next version. Use `RestApiHelper.withConfig` instead 
+> - mark `Request.withParam` as deprecated. It's will be removed in next version. Use `Request.withUrlParam` instead
 
 ## Installation
     npm install rest-api-helper
@@ -30,6 +38,10 @@ First thing first you need to configure helper:
         200
     ],
     "request": {
+       "getSomethingWithQuery": {
+          "method": "get",
+          "url": "something/get"
+       },
        "getSomethingById": {
           "method": "get",
           "url": "something/get/{id}"
@@ -38,7 +50,7 @@ First thing first you need to configure helper:
 }
 ```
  - Declare your requests in "request" property. 
- - Call `RestApiHelper.configure(require('your_config.json'));` first
+ - Call `RestApiHelper.builder().withConfig(require('your_config.json'));` first
  - Define yor API class. Example:
  ```
 import { RestApiHelper } from 'rest-api-helper';
@@ -53,12 +65,46 @@ class Api {
         const response = await RestApiHelper
             .build('getSomethingById')
             .withBody(body)
-            .withParam('id', id)
+            .withUrlParam('id', id)
+            .withHeaders({'Authorization': token})
+            .fetch();
+        return new SomeResponse(response.body);
+    }
+
+    async getSomethingWithQuery(userId, token) {
+        const response = await RestApiHelper
+            .build('getSomethingWithQuery')
+            .withQueryParams({ userId })
             .withHeaders({'Authorization': token})
             .fetch();
         return new SomeResponse(response.body);
     }
 }
+```
+- handle errors with interceptor:
+```
+export class InterceptorImpl {
+  constructor() {
+  }
+
+  public static buildErrorMessage(response) {
+    if (response.body.error && response.body.message) {
+      return `${response.body.error}: ${response.body.message}`;
+    }
+    return 'Server error';
+  }
+
+  public delegate(response) {
+    if (response.status > 200) {
+      alert(Interceptor.buildErrorMessage(response));
+    }
+  }
+}
+
+/*
+ * and use withInterceptor when build RestApiHelper
+ */
+ RestApiHelper.builder().withInterceptor(new InterceptorImpl()).withConfig(config);
 ```
 #### Note:
 > Response contains body and headers. If You need to know about response headers, just call `response.headers` besides `response.body`
@@ -109,7 +155,7 @@ async uploadPhoto(file: File) {
 Because that kind of logs supported only in V8 engine. We recommend use this hack before `RestApiHelper.config()`:
 ```
 config.logger = __DEV__ && Boolean(global.origin);
-RestApiHelper.configure(config);
+RestApiHelper.builder().withConfig(config);
 ```
 > Then logger will be working only in dev mode and debug-on mode   
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -40,6 +40,7 @@ interface Response {
 interface Request {
   withHeaders(headers: Headers): Request;
   withBody(body: Body): Request;
+  shouldBeIntercepted(value: boolean): Request;
   withQueryParams(params: QueryParams): Request;
   withUrlParam(name: string, value: string | number): Request;
   /*

--- a/index.d.ts
+++ b/index.d.ts
@@ -50,6 +50,10 @@ interface Request {
   fetch(): Promise<Response>;
 }
 
+export interface Interceptor {
+  delegate: (response: Response) => void; 
+}
+
 export class RestApiHelper {
   /*
    * @deprecated - use withConfig
@@ -59,7 +63,7 @@ export class RestApiHelper {
 
   static builder(): RestApiHelper;
   withConfig(config: any): RestApiHelper;
-  withInterceptor(interceptor: object): RestApiHelper;
+  withInterceptor(interceptor: Interceptor): RestApiHelper;
 }
 
 export default RestApiHelper;

--- a/index.d.ts
+++ b/index.d.ts
@@ -31,13 +31,13 @@ interface Headers {
   [key: string]: string;
 }
 
-interface Response {
+export interface Response {
   status: number;
   body: any;
   headers: Headers;
 }
 
-interface Request {
+export interface Request {
   withHeaders(headers: Headers): Request;
   withBody(body: Body): Request;
   shouldBeIntercepted(value: boolean): Request;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,24 +1,24 @@
 declare module 'rest-api-helper';
 
 interface RequestConfig {
-  url: string;
-  method: 'post' | 'get' | 'put' | 'delete' | 'head' | 'patch';
-  headers?: Headers;
+  url: string,
+  method: 'post' | 'get' | 'put' | 'delete' | 'head' | 'patch',
+  headers?: Headers,
 }
 
 export interface Config {
-  baseURL: string;
-  logger: boolean;
+  baseURL: string,
+  logger: boolean,
   statusDescription: {
-    [status: number]: string;
-  };
-  headers?: {
-    [key: string]: string;
+    [status: number]: string,
   },
-  successStatus: number[];
+  headers?: {
+    [key: string]: string,
+  },
+  successStatus: number[],
   request: {
-    [method: string]: RequestConfig;
-  };
+    [method: string]: RequestConfig,
+  },
 }
 
 interface Body {
@@ -50,8 +50,15 @@ interface Request {
 }
 
 export class RestApiHelper {
+  /*
+   * @deprecated - use withConfig
+   */
   static configure(config: Config): void;
   static build(method: string): Request;
+
+  static builder(): RestApiHelper;
+  withConfig(config: any): RestApiHelper;
+  withInterceptor(interceptor: object): RestApiHelper;
 }
 
 export default RestApiHelper;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,45 +1,52 @@
 declare module 'rest-api-helper';
 
 interface RequestConfig {
-  url: string,
-  method: 'post' | 'get' | 'put' | 'delete' | 'head' | 'patch',
-  headers?: Headers,
+  url: string;
+  method: 'post' | 'get' | 'put' | 'delete' | 'head' | 'patch';
+  headers?: Headers;
 }
 
 export interface Config {
-  baseURL: string,
-  logger: boolean,
+  baseURL: string;
+  logger: boolean;
   statusDescription: {
-    [status: number]: string,
-  },
+    [status: number]: string;
+  };
   headers?: {
-    [key: string]: string,
+    [key: string]: string;
   },
-  successStatus: number[],
+  successStatus: number[];
   request: {
-    [method: string]: RequestConfig,
-  },
+    [method: string]: RequestConfig;
+  };
 }
 
 interface Body {
-  [key: string]: any,
+  [key: string]: any;
 }
 
+type QueryParams = Body;
+
 interface Headers {
-  [key: string]: string,
+  [key: string]: string;
 }
 
 interface Response {
-  status: number,
-  body: any,
-  headers: Headers,
+  status: number;
+  body: any;
+  headers: Headers;
 }
 
 interface Request {
-  withHeaders(headers: Headers): Request,
-  withBody(body: Body): Request,
-  withParam(): Request,
-  fetch(): Promise<any>,
+  withHeaders(headers: Headers): Request;
+  withBody(body: Body): Request;
+  withQueryParams(params: QueryParams): Request;
+  withUrlParam(name: string, value: string | number): Request;
+  /*
+   * @deprecated - use withUrlParam
+   */
+  withParam(name: string, value: string | number): Request;
+  fetch(): Promise<Response>;
 }
 
 export class RestApiHelper {

--- a/index.js
+++ b/index.js
@@ -1,1 +1,4 @@
-export { RestApiHelper, RestApiHelper as default } from './src/RestApiHelper';
+import  { RestApiHelper as _RestApiHelper } from './src/RestApiHelper';
+
+export const RestApiHelper = _RestApiHelper;
+export default RestApiHelper;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rest-api-helper",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "REST API helper, JS fetch proxy",
   "main": "index.js",
   "scripts": {

--- a/src/Options.js
+++ b/src/Options.js
@@ -1,5 +1,5 @@
 import FormData from 'form-data';
-import { getQueryParameters, getFormURLEncodedBody } from './utils';
+import { getQueryParameters, getFormURLEncodedBody, isBodyNotAllowed } from './utils';
 import RFC from '../config/config';
 
 export class Options {
@@ -41,8 +41,10 @@ export class Options {
 	}
 
 	getUrl() {
-		const queryParams = this._isBodyNotAllowed(this.getMethod()) ? getQueryParameters(this.request.body) : '';
-		return this.getRequestUrl() + queryParams;
+		const oldParams = isBodyNotAllowed(this.getMethod()) ? this.request.body : {};
+		const queryParams = { ...oldParams, ...(this.request.queryParams || {})};
+		const paramsUrl = Object.keys(queryParams).length > 0 ? getQueryParameters(queryParams) : '';
+		return this.getRequestUrl() + paramsUrl;
 	}
 
 	getRequestUrl() {
@@ -58,7 +60,7 @@ export class Options {
 	}
 
 	getBody() {
-		if (this._isBodyNotAllowed(this.request.method)) {
+		if (isBodyNotAllowed(this.request.method)) {
 			return null;
 		}
 
@@ -85,11 +87,6 @@ export class Options {
 		else {
 			throw new Error(`Invalid method ${this.request.method}`);
 		}
-	}
-
-	_isBodyNotAllowed(method) {
-		const lowerCaseMethod = method.toLowerCase();
-		return lowerCaseMethod === 'get' || lowerCaseMethod === 'head';
 	}
 
 	_isFormURLEncoded() {

--- a/src/Options.js
+++ b/src/Options.js
@@ -31,6 +31,10 @@ export class Options {
 		this.baseURL = url;
 	}
 
+	getRelativeUrl() {
+		return this.request.url;
+	}
+
 	getOptions() {
 		return {
 			method: this.getMethod(),

--- a/src/Requst.js
+++ b/src/Requst.js
@@ -3,8 +3,11 @@ import { isBodyNotAllowed } from './utils';
 import { RestApiHelper } from './RestApiHelper';
 
 export class Request {
-	constructor(config) {
+	isInterceptionEnabled = true;
+
+	constructor(config, name) {
 		this._config = config;
+		this.requestName = name;
 	}
 
 	withHeaders(headers) {
@@ -51,6 +54,11 @@ export class Request {
 		else {
 			throw new Error(`param '{${name}}' does not declared in ${url}`);
 		}
+		return this;
+	}
+
+	shouldBeIntercepted(value = true) {
+		this.isInterceptionEnabled = value;
 		return this;
 	}
 

--- a/src/Requst.js
+++ b/src/Requst.js
@@ -1,5 +1,6 @@
 import FormData from 'form-data';
-import { RestApiHelper } from 'rest-api-helper/src/RestApiHelper';
+import { isBodyNotAllowed } from 'rest-api-helper/src/utils';
+import { RestApiHelper } from './RestApiHelper';
 
 export class Request {
 	constructor(config) {
@@ -15,7 +16,10 @@ export class Request {
 	}
 
 	withBody(body) {
-		if (body instanceof FormData) {
+		if (isBodyNotAllowed(this._config.method)) {
+			console.warn('RestApiHelper: Body for GET and HEAD queries is deprecated. Use "withQueryParams" instead');
+		}
+		if (body instanceof FormData || Array.isArray(body)) {
 			this._config.body = body;
 		}
 		else {
@@ -27,7 +31,19 @@ export class Request {
 		return this;
 	}
 
+	withQueryParams(params) {
+		this._config.queryParams = {
+			...(this._config.queryParams || {}),
+			...params,
+		};
+		return this;
+	}
+
 	withParam(name, value) {
+		return this.withUrlParam(name, value);
+	}
+
+	withUrlParam(name, value) {
 		const {url} = this._config;
 		if (url.search(`{${name}}`) !== -1) {
 			this._config.url = url.replace(`{${name}}`, `${value}`);

--- a/src/RestApiHelper.js
+++ b/src/RestApiHelper.js
@@ -87,10 +87,7 @@ export class RestApiHelper {
 
 	static _decorate(response, isInterceptionEnabled, requestName) {
 		if (RestApiHelper.interceptor && isInterceptionEnabled) {
-			RestApiHelper.interceptor.delegate({
-				status: response.status,
-				meta: response
-			})
+			RestApiHelper.interceptor.delegate(response);
 		}
 
 		if (RestApiHelper._isSuccess(response.status)) {

--- a/src/RestApiHelper.js
+++ b/src/RestApiHelper.js
@@ -1,10 +1,9 @@
-import { copyObject } from 'rest-api-helper/src/utils';
 import { Logger } from './api-hepler-logger';
 import RFC from '../config/config';
 import { Options } from './Options';
 import { RequestError } from './RequestError';
 import { Request } from './Requst';
-import { isApplicationJson, isTextPlain } from "./utils";
+import { isApplicationJson, isTextPlain, copyObject } from './utils';
 
 export class RestApiHelper {
 	static _config = {};
@@ -72,7 +71,7 @@ export class RestApiHelper {
 		if (RestApiHelper._isSuccess(response.status)) {
 			return response;
 		}
-		const message = {status: `${response.status} ${RestApiHelper._config.statusDescription[response.status] || config.status[response.status]}`};
+		const message = {status: `${response.status} ${RestApiHelper._config.statusDescription[response.status] || RFC.status[response.status]}`};
 		Logger.log('ApiHelper/ERROR:', message, 'red');
 
 		throw new RequestError(`${response.status}`, `${RestApiHelper._config.statusDescription[response.status] || RFC.status[response.status]}`, JSON.stringify(response.body));

--- a/src/api-hepler-logger.js
+++ b/src/api-hepler-logger.js
@@ -16,7 +16,7 @@ export class Logger {
 	static log(message, log, options) {
 		if (this._option) {
 			try {
-				console.groupCollapsed('%c action', style.thin, message);
+				console.groupCollapsed('%c fetch', style.thin, message);
 			}
 			catch (e) {
 				//that's okay, console.groupCollapsed doesn't supported js engine

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,7 +6,7 @@ export function copyObject(obj) {
 }
 
 function getValue(key, value) {
-	return `${key}=${value}`;
+	return `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`;
 }
 
 export function getQueryParameters(body) {
@@ -65,4 +65,9 @@ export function isTextPlain(headers) {
 
 export function isApplicationJson(headers) {
 	return (headers['content-type'].toLowerCase()).indexOf(APPLICATION_JSON) !== -1;
+}
+
+export function isBodyNotAllowed(method) {
+	const lowerCaseMethod = method.toLowerCase();
+	return lowerCaseMethod === 'get' || lowerCaseMethod === 'head';
 }


### PR DESCRIPTION
- merge interceptor and save backward compatibility
- implements `withQueryParams` for `Request`. It's work with all (get, post...) queries
- refactoring and types fixes